### PR TITLE
V1.0.0 ffxblue changes to update package paths and pass field info via context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# graphql-go [![Sourcegraph](https://sourcegraph.com/github.com/graph-gophers/graphql-go/-/badge.svg)](https://sourcegraph.com/github.com/graph-gophers/graphql-go?badge) [![Build Status](https://semaphoreci.com/api/v1/graph-gophers/graphql-go/branches/master/badge.svg)](https://semaphoreci.com/graph-gophers/graphql-go) [![GoDoc](https://godoc.org/github.com/graph-gophers/graphql-go?status.svg)](https://godoc.org/github.com/graph-gophers/graphql-go)
+# graphql-go [![Sourcegraph](https://sourcegraph.com/github.com/ffxblue/graphql-go/-/badge.svg)](https://sourcegraph.com/github.com/ffxblue/graphql-go?badge) [![Build Status](https://semaphoreci.com/api/v1/graph-gophers/graphql-go/branches/master/badge.svg)](https://semaphoreci.com/graph-gophers/graphql-go) [![GoDoc](https://godoc.org/github.com/ffxblue/graphql-go?status.svg)](https://godoc.org/github.com/ffxblue/graphql-go)
 
 <p align="center"><img src="docs/img/logo.png" width="300"></p>
 
@@ -21,7 +21,7 @@ safe for production use.
 
 ## Roadmap
 
-We're trying out the GitHub Project feature to manage `graphql-go`'s [development roadmap](https://github.com/graph-gophers/graphql-go/projects/1).
+We're trying out the GitHub Project feature to manage `graphql-go`'s [development roadmap](https://github.com/ffxblue/graphql-go/projects/1).
 Feedback is welcome and appreciated.
 
 ## (Some) Documentation
@@ -35,8 +35,8 @@ import (
         "log"
         "net/http"
 
-        graphql "github.com/graph-gophers/graphql-go"
-        "github.com/graph-gophers/graphql-go/relay"
+        graphql "github.com/ffxblue/graphql-go"
+        "github.com/ffxblue/graphql-go/relay"
 )
 
 type query struct{}
@@ -162,6 +162,6 @@ Which could produce a GraphQL error such as:
 }
 ```
 
-### [Examples](https://github.com/graph-gophers/graphql-go/wiki/Examples)
+### [Examples](https://github.com/ffxblue/graphql-go/wiki/Examples)
 
-### [Companies that use this library](https://github.com/graph-gophers/graphql-go/wiki/Users)
+### [Companies that use this library](https://github.com/ffxblue/graphql-go/wiki/Users)

--- a/example/caching/caching.go
+++ b/example/caching/caching.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/graph-gophers/graphql-go/example/caching/cache"
+	"github.com/ffxblue/graphql-go/example/caching/cache"
 )
 
 const Schema = `

--- a/example/caching/server/server.go
+++ b/example/caching/server/server.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/example/caching"
-	"github.com/graph-gophers/graphql-go/example/caching/cache"
+	"github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/example/caching"
+	"github.com/ffxblue/graphql-go/example/caching/cache"
 )
 
 var schema *graphql.Schema

--- a/example/customerrors/server/server.go
+++ b/example/customerrors/server/server.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/example/customerrors"
-	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/example/customerrors"
+	"github.com/ffxblue/graphql-go/relay"
 )
 
 var schema *graphql.Schema

--- a/example/customerrors/starwars.go
+++ b/example/customerrors/starwars.go
@@ -3,7 +3,7 @@ package customerrors
 import (
 	"fmt"
 
-	"github.com/graph-gophers/graphql-go"
+	"github.com/ffxblue/graphql-go"
 )
 
 var Schema = `

--- a/example/social/server/server.go
+++ b/example/social/server/server.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/example/social"
-	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/example/social"
+	"github.com/ffxblue/graphql-go/relay"
 )
 
 func main() {

--- a/example/social/social.go
+++ b/example/social/social.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
+	"github.com/ffxblue/graphql-go"
 )
 
 const Schema = `

--- a/example/starwars/server/server.go
+++ b/example/starwars/server/server.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/example/starwars"
-	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/example/starwars"
+	"github.com/ffxblue/graphql-go/relay"
 )
 
 var schema *graphql.Schema

--- a/example/starwars/starwars.go
+++ b/example/starwars/starwars.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	graphql "github.com/graph-gophers/graphql-go"
+	graphql "github.com/ffxblue/graphql-go"
 )
 
 var Schema = `

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/graph-gophers/graphql-go
+module github.com/ffxblue/graphql-go
 
 require github.com/opentracing/opentracing-go v1.1.0
 

--- a/gqltesting/subscriptions.go
+++ b/gqltesting/subscriptions.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"testing"
 
-	graphql "github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/errors"
+	graphql "github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/errors"
 )
 
 // TestResponse models the expected response

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"testing"
 
-	graphql "github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/errors"
+	graphql "github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/errors"
 )
 
 // Test is a GraphQL test case to be used with RunTest(s).

--- a/graphql.go
+++ b/graphql.go
@@ -7,17 +7,17 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/exec"
-	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
-	"github.com/graph-gophers/graphql-go/internal/exec/selected"
-	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/schema"
-	"github.com/graph-gophers/graphql-go/internal/validation"
-	"github.com/graph-gophers/graphql-go/introspection"
-	"github.com/graph-gophers/graphql-go/log"
-	"github.com/graph-gophers/graphql-go/trace"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/exec"
+	"github.com/ffxblue/graphql-go/internal/exec/resolvable"
+	"github.com/ffxblue/graphql-go/internal/exec/selected"
+	"github.com/ffxblue/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/internal/validation"
+	"github.com/ffxblue/graphql-go/introspection"
+	"github.com/ffxblue/graphql-go/log"
+	"github.com/ffxblue/graphql-go/trace"
 )
 
 // ParseSchema parses a GraphQL schema and attaches the given root resolver. It returns an error if

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
-	gqlerrors "github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/example/starwars"
-	"github.com/graph-gophers/graphql-go/gqltesting"
+	"github.com/ffxblue/graphql-go"
+	gqlerrors "github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/example/starwars"
+	"github.com/ffxblue/graphql-go/gqltesting"
 )
 
 type helloWorldResolver1 struct{}

--- a/internal/common/lexer.go
+++ b/internal/common/lexer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/scanner"
 
-	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/errors"
 )
 
 type syntaxError string

--- a/internal/common/lexer_test.go
+++ b/internal/common/lexer_test.go
@@ -3,7 +3,7 @@ package common_test
 import (
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/common"
 )
 
 type consumeTestCase struct {

--- a/internal/common/literals.go
+++ b/internal/common/literals.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"text/scanner"
 
-	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/errors"
 )
 
 type Literal interface {

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/errors"
 )
 
 type Type interface {

--- a/internal/common/values.go
+++ b/internal/common/values.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/errors"
 )
 
 // http://facebook.github.io/graphql/draft/#InputValueDefinition

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -202,7 +202,8 @@ func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f
 		if f.field.UseMethodResolver() {
 			var in []reflect.Value
 			if f.field.HasContext {
-				in = append(in, reflect.ValueOf(traceCtx))
+				execCtx := WithField(traceCtx, Field{Alias: path.value.(string), Name: f.field.Name})
+				in = append(in, reflect.ValueOf(execCtx))
 			}
 			if f.field.ArgsPacker != nil {
 				in = append(in, f.field.PackedArgs)

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -9,14 +9,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
-	"github.com/graph-gophers/graphql-go/internal/exec/selected"
-	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/schema"
-	"github.com/graph-gophers/graphql-go/log"
-	"github.com/graph-gophers/graphql-go/trace"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/exec/resolvable"
+	"github.com/ffxblue/graphql-go/internal/exec/selected"
+	"github.com/ffxblue/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/log"
+	"github.com/ffxblue/graphql-go/trace"
 )
 
 type Request struct {

--- a/internal/exec/packer/packer.go
+++ b/internal/exec/packer/packer.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/schema"
 )
 
 type packer interface {

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/schema"
-	"github.com/graph-gophers/graphql-go/introspection"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/introspection"
 )
 
 // Meta defines the details of the metadata schema for introspection.

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/exec/packer"
-	"github.com/graph-gophers/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/exec/packer"
+	"github.com/ffxblue/graphql-go/internal/schema"
 )
 
 type Schema struct {

--- a/internal/exec/resolve.go
+++ b/internal/exec/resolve.go
@@ -1,0 +1,24 @@
+package exec
+
+import "context"
+
+type contextKey string
+
+const field contextKey = "field"
+
+// Field being resolved for a request.
+type Field struct {
+	Alias string
+	Name  string
+}
+
+// FieldFromContext that is currently being resolved.
+// May only be called from a resolver function, using the context it was provided.
+func FieldFromContext(ctx context.Context) Field {
+	return ctx.Value(field).(Field)
+}
+
+// WithField being resolved. Used internally for
+func WithField(ctx context.Context, f Field) context.Context {
+	return context.WithValue(ctx, field, f)
+}

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -5,13 +5,13 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/exec/packer"
-	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
-	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/schema"
-	"github.com/graph-gophers/graphql-go/introspection"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/exec/packer"
+	"github.com/ffxblue/graphql-go/internal/exec/resolvable"
+	"github.com/ffxblue/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/introspection"
 )
 
 type Request struct {

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -8,11 +8,11 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
-	"github.com/graph-gophers/graphql-go/internal/exec/selected"
-	"github.com/graph-gophers/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/exec/resolvable"
+	"github.com/ffxblue/graphql-go/internal/exec/selected"
+	"github.com/ffxblue/graphql-go/internal/query"
 )
 
 type Response struct {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"text/scanner"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
 )
 
 type Document struct {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"text/scanner"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
 )
 
 // Schema represents a GraphQL service's collective type system capabilities.

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -3,8 +3,8 @@ package schema
 import (
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
 )
 
 func TestParseInterfaceDef(t *testing.T) {

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/internal/schema"
 )
 
 func TestParse(t *testing.T) {

--- a/internal/validation/testdata/package.json
+++ b/internal/validation/testdata/package.json
@@ -22,12 +22,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/graph-gophers/graphql-go.git"
+    "url": "git+https://github.com/ffxblue/graphql-go.git"
   },
   "author": "",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/graph-gophers/graphql-go/issues"
+    "url": "https://github.com/ffxblue/graphql-go/issues"
   },
-  "homepage": "https://github.com/graph-gophers/graphql-go#readme"
+  "homepage": "https://github.com/ffxblue/graphql-go#readme"
 }

--- a/internal/validation/validate_max_depth_test.go
+++ b/internal/validation/validate_max_depth_test.go
@@ -3,8 +3,8 @@ package validation
 import (
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/internal/schema"
 )
 
 const (

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"text/scanner"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/internal/schema"
 )
 
 type varSet map[*common.InputValue]struct{}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -8,10 +8,10 @@ import (
 
 	"encoding/json"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/schema"
-	"github.com/graph-gophers/graphql-go/internal/validation"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/internal/validation"
 )
 
 type Test struct {

--- a/introspection.go
+++ b/introspection.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
-	"github.com/graph-gophers/graphql-go/introspection"
+	"github.com/ffxblue/graphql-go/internal/exec/resolvable"
+	"github.com/ffxblue/graphql-go/introspection"
 )
 
 // Inspect allows inspection of the given schema.

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -3,8 +3,8 @@ package introspection
 import (
 	"sort"
 
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/schema"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/schema"
 )
 
 type Schema struct {

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -6,9 +6,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/example/social"
-	"github.com/graph-gophers/graphql-go/example/starwars"
+	"github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/example/social"
+	"github.com/ffxblue/graphql-go/example/starwars"
 )
 
 var socialSchema = graphql.MustParseSchema(social.Schema, &social.Resolver{}, graphql.UseFieldResolvers())

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	graphql "github.com/graph-gophers/graphql-go"
+	graphql "github.com/ffxblue/graphql-go"
 )
 
 func MarshalID(kind string, spec interface{}) graphql.ID {

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/example/starwars"
-	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/ffxblue/graphql-go"
+	"github.com/ffxblue/graphql-go/example/starwars"
+	"github.com/ffxblue/graphql-go/relay"
 )
 
 var starwarsSchema = graphql.MustParseSchema(starwars.Schema, &starwars.Resolver{})

--- a/selection/field.go
+++ b/selection/field.go
@@ -1,0 +1,16 @@
+package selection
+
+import (
+	"context"
+
+	"github.com/ffxblue/graphql-go/internal/exec"
+)
+
+// Field being resolved for a request.
+type Field exec.Field
+
+// FieldFromContext that is currently being resolved.
+// May only be called from a resolver function, using the context it was provided.
+func FieldFromContext(ctx context.Context) Field {
+	return Field(exec.FieldFromContext(ctx))
+}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	graphql "github.com/graph-gophers/graphql-go"
-	qerrors "github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/gqltesting"
+	graphql "github.com/ffxblue/graphql-go"
+	qerrors "github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/gqltesting"
 )
 
 type rootResolver struct {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 	"reflect"
 
-	qerrors "github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/internal/exec"
-	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
-	"github.com/graph-gophers/graphql-go/internal/exec/selected"
-	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/validation"
-	"github.com/graph-gophers/graphql-go/introspection"
+	qerrors "github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/internal/common"
+	"github.com/ffxblue/graphql-go/internal/exec"
+	"github.com/ffxblue/graphql-go/internal/exec/resolvable"
+	"github.com/ffxblue/graphql-go/internal/exec/selected"
+	"github.com/ffxblue/graphql-go/internal/query"
+	"github.com/ffxblue/graphql-go/internal/validation"
+	"github.com/ffxblue/graphql-go/introspection"
 )
 
 // Subscribe returns a response channel for the given subscription with the schema's

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/introspection"
+	"github.com/ffxblue/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/introspection"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"

--- a/trace/validation_trace.go
+++ b/trace/validation_trace.go
@@ -3,7 +3,7 @@ package trace
 import (
 	"context"
 
-	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/ffxblue/graphql-go/errors"
 )
 
 type TraceValidationFinishFunc = TraceQueryFinishFunc


### PR DESCRIPTION
The PR includes two commits based on [graph-gophers/graphql-go](https://github.com/graph-gophers/graphql-go) v1.0.0 initial release (commit `21b77bd`)

* **4c23e92** - (HEAD -> v1.0.0-ffxblue-changes, origin/v1.0.0-ffxblue-changes) Port change of commit 6b74704 - Pass Field Info via Context (19 hours ago) <Eve.Liu>
* **487dc46** - Update package paths to fork repo (19 hours ago) <Eve.Liu>

*   21b77bd - (origin/v1.0.0-original, v1.0.0-original) Merge pull request #443 from eko/fix-369 (3 years, 4 months ago) <Pavel Nikolov>